### PR TITLE
rtmp2: Use manual URI path handling

### DIFF
--- a/gst/rtmp2/gstrtmp2locationhandler.c
+++ b/gst/rtmp2/gstrtmp2locationhandler.c
@@ -20,6 +20,7 @@
 #include "gstrtmp2locationhandler.h"
 #include "rtmp/rtmputils.h"
 #include "rtmp/rtmpclient.h"
+#include <string.h>
 
 #define DEFAULT_SCHEME GST_RTMP_SCHEME_RTMP
 #define DEFAULT_HOST "localhost"
@@ -122,83 +123,12 @@ uri_handler_get_uri (GstURIHandler * handler)
 }
 
 static gboolean
-parse_path (const gchar * string, GstUri * uri, gchar ** application,
-    gchar ** stream, GError ** error)
-{
-  gchar *query;
-  GList *segments;
-  guint nsegments;
-
-  g_return_val_if_fail (uri, FALSE);
-  g_return_val_if_fail (application, FALSE);
-  g_return_val_if_fail (stream, FALSE);
-
-  query = gst_uri_get_query_string (uri);
-  segments = gst_uri_get_path_segments (uri);
-  nsegments = g_list_length (segments);
-
-  /* Test if too short, or not absolute */
-  if (nsegments < 3) {
-    g_set_error (error, GST_URI_ERROR, GST_URI_ERROR_BAD_REFERENCE,
-        "URI path too short: %s", string);
-    goto err;
-  }
-
-  if (segments->data != NULL) {
-    g_set_error (error, GST_URI_ERROR, GST_URI_ERROR_BAD_REFERENCE,
-        "URI path not absolute: %s", string);
-    goto err;
-  }
-
-  /* Strip root */
-  segments = g_list_delete_link (segments, segments);
-
-  /* Extract stream */
-  {
-    GList *segment = g_list_last (segments);
-    gchar *streamname = segment->data;
-
-    if (query && query[0]) {
-      *stream = g_strconcat (streamname ? streamname : "", "?", query, NULL);
-      g_free (streamname);
-    } else if (streamname) {
-      *stream = streamname;
-    } else {
-      g_set_error (error, GST_URI_ERROR, GST_URI_ERROR_BAD_REFERENCE,
-          "URI lacks stream: %s", string);
-      goto err;
-    }
-
-    /* Strip stream, leaving app path */
-    segments = g_list_delete_link (segments, segment);
-  }
-
-  {
-    GstUri *tempuri =
-        gst_uri_new (NULL, NULL, NULL, GST_URI_NO_PORT, NULL, NULL, NULL);
-
-    gst_uri_set_path_segments (tempuri, segments);
-
-    *application = gst_uri_get_path (tempuri);
-    gst_uri_unref (tempuri);
-  }
-
-  g_free (query);
-  return TRUE;
-
-err:
-  g_list_free_full (segments, g_free);
-  g_free (query);
-  return FALSE;
-}
-
-static gboolean
 uri_handler_set_uri (GstURIHandler * handler, const gchar * string,
     GError ** error)
 {
   GstRtmpLocationHandler *self = GST_RTMP_LOCATION_HANDLER (handler);
   GstUri *uri;
-  const gchar *host, *userinfo;
+  const gchar *scheme_sep, *path_sep, *stream_sep, *host, *userinfo;
   GstRtmpScheme scheme;
   guint port;
   gboolean ret = FALSE;
@@ -206,7 +136,33 @@ uri_handler_set_uri (GstURIHandler * handler, const gchar * string,
   GST_DEBUG_OBJECT (self, "setting URI to %s", GST_STR_NULL (string));
   g_return_val_if_fail (string, FALSE);
 
-  uri = gst_uri_from_string (string);
+  scheme_sep = strstr (string, "://");
+  if (!scheme_sep) {
+    g_set_error (error, GST_URI_ERROR, GST_URI_ERROR_BAD_REFERENCE,
+        "URI lacks scheme: %s", string);
+    return FALSE;
+  }
+
+  path_sep = strchr (scheme_sep + 3, '/');
+  if (!path_sep) {
+    g_set_error (error, GST_URI_ERROR, GST_URI_ERROR_BAD_REFERENCE,
+        "URI lacks path: %s", string);
+    return FALSE;
+  }
+
+  stream_sep = strrchr (path_sep + 1, '/');
+  if (!stream_sep) {
+    g_set_error (error, GST_URI_ERROR, GST_URI_ERROR_BAD_REFERENCE,
+        "URI lacks stream: %s", string);
+    return FALSE;
+  }
+
+  {
+    gchar *string_without_path = g_strndup (string, path_sep - string);
+    uri = gst_uri_from_string (string_without_path);
+    g_free (string_without_path);
+  }
+
   if (!uri) {
     g_set_error (error, GST_URI_ERROR, GST_URI_ERROR_BAD_URI,
         "URI failed to parse: %s", string);
@@ -235,18 +191,14 @@ uri_handler_set_uri (GstURIHandler * handler, const gchar * string,
   }
 
   {
-    gchar *application, *stream;
-
-    if (!parse_path (string, uri, &application, &stream, error)) {
-      goto out;
-    }
+    const gchar *path = path_sep + 1, *stream = stream_sep + 1;
+    gchar *application = g_strndup (path, stream_sep - path);
 
     g_object_set (self, "scheme", scheme, "host", host, "port", port,
         "application", application, "stream", stream, "username", NULL,
         "password", NULL, NULL);
 
     g_free (application);
-    g_free (stream);
   }
 
   userinfo = gst_uri_get_userinfo (uri);

--- a/gst/rtmp2/gstrtmp2locationhandler.c
+++ b/gst/rtmp2/gstrtmp2locationhandler.c
@@ -198,7 +198,7 @@ uri_handler_set_uri (GstURIHandler * handler, const gchar * string,
 {
   GstRtmpLocationHandler *self = GST_RTMP_LOCATION_HANDLER (handler);
   GstUri *uri;
-  const gchar *scheme_string, *host, *userinfo;
+  const gchar *host, *userinfo;
   GstRtmpScheme scheme;
   gchar *application, *stream;
   guint port;
@@ -215,17 +215,10 @@ uri_handler_set_uri (GstURIHandler * handler, const gchar * string,
 
   gst_uri_normalize (uri);
 
-  scheme_string = gst_uri_get_scheme (uri);
-  if (!scheme_string) {
-    g_set_error (error, GST_URI_ERROR, GST_URI_ERROR_BAD_REFERENCE,
-        "URI lacks scheme: %s", string);
-    goto out;
-  }
-
-  scheme = gst_rtmp_scheme_from_string (scheme_string);
+  scheme = gst_rtmp_scheme_from_uri (uri);
   if (scheme < 0) {
     g_set_error (error, GST_URI_ERROR, GST_URI_ERROR_BAD_REFERENCE,
-        "URI has bad scheme '%s': %s", scheme_string, string);
+        "URI has bad scheme: %s", string);
     goto out;
   }
 

--- a/gst/rtmp2/gstrtmp2locationhandler.c
+++ b/gst/rtmp2/gstrtmp2locationhandler.c
@@ -41,8 +41,8 @@ GST_DEBUG_CATEGORY_STATIC (GST_CAT_DEFAULT);
 static void
 gst_rtmp_location_handler_default_init (GstRtmpLocationHandlerInterface * iface)
 {
-  GST_DEBUG_CATEGORY_INIT (GST_CAT_DEFAULT, "rtmp2urihandler", 0,
-      "RTMP2 URI Handling");
+  GST_DEBUG_CATEGORY_INIT (GST_CAT_DEFAULT, "rtmp2locationhandler", 0,
+      "RTMP2 Location Handling");
 
   g_object_interface_install_property (iface, g_param_spec_string ("location",
           "Location", "Location of RTMP stream to access", DEFAULT_LOCATION,

--- a/gst/rtmp2/gstrtmp2locationhandler.c
+++ b/gst/rtmp2/gstrtmp2locationhandler.c
@@ -133,7 +133,7 @@ uri_handler_set_uri (GstURIHandler * handler, const gchar * string,
   guint port;
   gboolean ret = FALSE;
 
-  GST_DEBUG_OBJECT (self, "setting URI to %s", GST_STR_NULL (string));
+  GST_DEBUG_OBJECT (self, "setting URI from %s", GST_STR_NULL (string));
   g_return_val_if_fail (string, FALSE);
 
   scheme_sep = strstr (string, "://");
@@ -193,6 +193,9 @@ uri_handler_set_uri (GstURIHandler * handler, const gchar * string,
   {
     const gchar *path = path_sep + 1, *stream = stream_sep + 1;
     gchar *application = g_strndup (path, stream_sep - path);
+
+    GST_DEBUG_OBJECT (self, "setting location to %s://%s:%u/%s stream %s",
+        gst_rtmp_scheme_to_string (scheme), host, port, application, stream);
 
     g_object_set (self, "scheme", scheme, "host", host, "port", port,
         "application", application, "stream", stream, "username", NULL,

--- a/gst/rtmp2/gstrtmp2locationhandler.c
+++ b/gst/rtmp2/gstrtmp2locationhandler.c
@@ -205,11 +205,12 @@ uri_handler_set_uri (GstURIHandler * handler, const gchar * string,
   gboolean ret = FALSE;
 
   GST_DEBUG_OBJECT (self, "setting URI to %s", GST_STR_NULL (string));
+  g_return_val_if_fail (string, FALSE);
 
   uri = gst_uri_from_string (string);
   if (!uri) {
     g_set_error (error, GST_URI_ERROR, GST_URI_ERROR_BAD_URI,
-        "URI failed to parse: %s", GST_STR_NULL (string));
+        "URI failed to parse: %s", string);
     return FALSE;
   }
 

--- a/gst/rtmp2/gstrtmp2locationhandler.c
+++ b/gst/rtmp2/gstrtmp2locationhandler.c
@@ -200,7 +200,6 @@ uri_handler_set_uri (GstURIHandler * handler, const gchar * string,
   GstUri *uri;
   const gchar *host, *userinfo;
   GstRtmpScheme scheme;
-  gchar *application, *stream;
   guint port;
   gboolean ret = FALSE;
 
@@ -235,16 +234,20 @@ uri_handler_set_uri (GstURIHandler * handler, const gchar * string,
     port = gst_rtmp_scheme_get_default_port (scheme);
   }
 
-  if (!parse_path (string, uri, &application, &stream, error)) {
-    goto out;
+  {
+    gchar *application, *stream;
+
+    if (!parse_path (string, uri, &application, &stream, error)) {
+      goto out;
+    }
+
+    g_object_set (self, "scheme", scheme, "host", host, "port", port,
+        "application", application, "stream", stream, "username", NULL,
+        "password", NULL, NULL);
+
+    g_free (application);
+    g_free (stream);
   }
-
-  g_object_set (self, "scheme", scheme, "host", host, "port", port,
-      "application", application, "stream", stream, "username", NULL,
-      "password", NULL, NULL);
-
-  g_free (application);
-  g_free (stream);
 
   userinfo = gst_uri_get_userinfo (uri);
   if (userinfo) {

--- a/gst/rtmp2/rtmp/rtmpclient.c
+++ b/gst/rtmp2/rtmp/rtmpclient.c
@@ -96,6 +96,17 @@ gst_rtmp_scheme_from_string (const gchar * string)
   return -1;
 }
 
+GstRtmpScheme
+gst_rtmp_scheme_from_uri (const GstUri * uri)
+{
+  const gchar *scheme = gst_uri_get_scheme (uri);
+  if (!scheme) {
+    return GST_RTMP_SCHEME_RTMP;
+  }
+
+  return gst_rtmp_scheme_from_string (scheme);
+}
+
 const gchar *
 gst_rtmp_scheme_to_string (GstRtmpScheme scheme)
 {

--- a/gst/rtmp2/rtmp/rtmpclient.c
+++ b/gst/rtmp2/rtmp/rtmpclient.c
@@ -205,7 +205,7 @@ gst_rtmp_location_get_string (const GstRtmpLocation * location,
     gboolean with_stream)
 {
   GstUri *uri;
-  gchar *string;
+  gchar *base, *string;
   const gchar *scheme_string;
   guint default_port;
 
@@ -217,19 +217,12 @@ gst_rtmp_location_get_string (const GstRtmpLocation * location,
   uri = gst_uri_new (scheme_string, NULL, location->host,
       location->port == default_port ? GST_URI_NO_PORT : location->port, "/",
       NULL, NULL);
+  base = gst_uri_to_string (uri);
 
-  gst_uri_append_path (uri, location->application);
+  string = g_strconcat (base, location->application, with_stream ? "/" : NULL,
+      location->stream, NULL);
 
-  if (with_stream && location->stream) {
-    gchar **parts = g_strsplit (location->stream, "?", 2);
-    gst_uri_append_path_segment (uri, parts[0]);
-    if (parts[0] && parts[1]) {
-      gst_uri_set_query_string (uri, parts[1]);
-    }
-    g_strfreev (parts);
-  }
-
-  string = gst_uri_to_string (uri);
+  g_free (base);
   gst_uri_unref (uri);
 
   return string;

--- a/gst/rtmp2/rtmp/rtmpclient.h
+++ b/gst/rtmp2/rtmp/rtmpclient.h
@@ -35,6 +35,7 @@ typedef enum
 GType gst_rtmp_scheme_get_type (void);
 
 GstRtmpScheme gst_rtmp_scheme_from_string (const gchar * string);
+GstRtmpScheme gst_rtmp_scheme_from_uri (const GstUri * uri);
 const gchar * gst_rtmp_scheme_to_string (GstRtmpScheme scheme);
 const gchar * const * gst_rtmp_scheme_get_strings (void);
 guint gst_rtmp_scheme_get_default_port (GstRtmpScheme scheme);


### PR DESCRIPTION
RTMP URIs apparently can have `?` `#`-style parameters attached to either the application path or the stream name. `GstUri` can't parse this. However, we still want it to parse the host part of the URI.